### PR TITLE
Support channels

### DIFF
--- a/client.go
+++ b/client.go
@@ -26,6 +26,10 @@ type apiListResponse struct {
 	Data []*HealthcheckResponse `json:"checks"`
 }
 
+type apiListChannelsResponse struct {
+	Data []*HealthcheckChannelResponse `json:"channels"`
+}
+
 type apiErrorResponse struct {
 	Message string `json:"error"`
 }
@@ -172,6 +176,22 @@ func (c *Client) Delete(id string) (*HealthcheckResponse, error) {
 	return &resp, nil
 }
 
+// GetAllChannels returns all channels
+func (c *Client) GetAllChannels() ([]*HealthcheckChannelResponse, error) {
+	body, err := c.get("/channels/")
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := toAPIListChannelsResponse(body)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := (*r).Data
+	return resp, nil
+}
+
 func toAPIListResponse(body []byte) (*apiListResponse, error) {
 	var s = new(apiListResponse)
 	err := json.Unmarshal(body, &s)
@@ -180,6 +200,12 @@ func toAPIListResponse(body []byte) (*apiListResponse, error) {
 
 func toAPIResponse(body []byte) (*apiResponse, error) {
 	var s = new(apiResponse)
+	err := json.Unmarshal(body, &s)
+	return s, err
+}
+
+func toAPIListChannelsResponse(body []byte) (*apiListChannelsResponse, error) {
+	var s = new(apiListChannelsResponse)
 	err := json.Unmarshal(body, &s)
 	return s, err
 }

--- a/client_test.go
+++ b/client_test.go
@@ -92,4 +92,14 @@ func TestClient(t *testing.T) {
 	}
 
 	log.Printf("[DEBUG] Deleted %s", deleted)
+
+	// GetAllChannels
+	// ----------------------------------------
+	channels, err := client.GetAllChannels()
+	if err != nil {
+		t.Error("Fetching channels failed.", err)
+		return
+	}
+
+	log.Printf("[DEBUG] Fetched %s", channels)
 }

--- a/healtcheck.go
+++ b/healtcheck.go
@@ -35,6 +35,13 @@ type HealthcheckResponse struct {
 	UpdateURL string `json:"update_url,omitempty"`
 }
 
+// HealthcheckChannelResponse represents a channel response of healthcheck api
+type HealthcheckChannelResponse struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+	Kind string `json:"kind,omitempty"`
+}
+
 // ToJSON returns a json representation of a healthcheck data
 func (hc *Healthcheck) ToJSON() (string, error) {
 	b, err := json.Marshal(hc)
@@ -60,6 +67,23 @@ func (hc *HealthcheckResponse) ToJSON() (string, error) {
 }
 
 func (hc *HealthcheckResponse) String() string {
+	json, err := hc.ToJSON()
+	if err != nil {
+		return err.Error()
+	}
+	return json
+}
+
+// ToJSON returns a json representation of a healthcheck channel
+func (hc *HealthcheckChannelResponse) ToJSON() (string, error) {
+	b, err := json.MarshalIndent(hc, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func (hc *HealthcheckChannelResponse) String() string {
 	json, err := hc.ToJSON()
 	if err != nil {
 		return err.Error()

--- a/healtcheck.go
+++ b/healtcheck.go
@@ -19,6 +19,7 @@ type Healthcheck struct {
 
 // HealthcheckResponse represents a healthcheck api response
 type HealthcheckResponse struct {
+	Channels  string `json:"channels,omitempty"`
 	Grace     int    `json:"grace,omitempty"`
 	LastPing  string `json:"last_ping,omitempty"`
 	Name      string `json:"name,omitempty"`

--- a/healtcheck.go
+++ b/healtcheck.go
@@ -31,7 +31,7 @@ type HealthcheckResponse struct {
 	Status    string `json:"status,omitempty"`
 	Tags      string `json:"tags,omitempty"`
 	Timeout   int    `json:"timeout,omitempty"`
-	Timezone  string `json:"tz,omitempty,omitempty"`
+	Timezone  string `json:"tz,omitempty"`
 	UpdateURL string `json:"update_url,omitempty"`
 }
 


### PR DESCRIPTION
Hi @kristofferahl,

I supported healthchecks channels.

* Users can find `Channels` in HealthcheckResponse
    * This parameter was supported from [healthchecks v1.3.0](https://github.com/healthchecks/healthchecks/releases/tag/v1.3.0)
* Users can execute `Client.GetAllChannels()`
    * See https://healthchecks.io/docs/api/#list-channels

Also I'll create PR to https://github.com/kristofferahl/terraform-provider-healthchecksio soon. :smile: