### PR TITLE
Wrapping api errors and pluggable logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ func main() {
 
 Docs can be found at [godoc.org](https://godoc.org/github.com/kristofferahl/go-healthchecksio).
 
+## A note on logging
+
+By default this package uses the NoOpLogger, essentially turning off all logging. For basic logging you may configure the client to use the included logger StandardLogger. You may also choose to supply your own logger by implementing the Logger interface.
+
+```go
+client := healthchecksio.NewClient(apiKey)
+client.Log = &healthchecksio.StandardLogger{}
+```
+
+
 ## Developing
 
 Running the tests requires a valid healthchecks.io API key (See https://healthchecks.io/docs/api/). Make sure the following environment variables are set.

--- a/client.go
+++ b/client.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 )
 
@@ -18,6 +17,7 @@ type Client struct {
 	BaseURL     string
 	ContentType string
 	HTTPClient  *http.Client
+	Log         Logger
 }
 
 type apiResponse HealthcheckResponse
@@ -41,6 +41,7 @@ func NewClient(apiKey string) *Client {
 		BaseURL:     baseURL,
 		ContentType: "application/json",
 		HTTPClient:  &http.Client{},
+		Log:         &NoOpLogger{},
 	}
 }
 
@@ -71,7 +72,7 @@ func (c *Client) request(method string, path string, reader io.Reader) ([]byte, 
 	req.Header.Set("Content-Type", c.ContentType)
 	req.Header.Set("X-Api-Key", c.APIKey)
 
-	log.Printf("[DEBUG] HTTP %s %s", method, url)
+	c.Log.Debugf("HTTP %s %s", method, url)
 
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -67,7 +67,7 @@ func wrapError(err error, req *http.Request, res *http.Response) error {
 }
 
 func (c *Client) request(method string, path string, reader io.Reader) ([]byte, error) {
-	url := baseURL + path
+	url := c.BaseURL + path
 	req, _ := http.NewRequest(method, url, reader)
 	req.Header.Set("Content-Type", c.ContentType)
 	req.Header.Set("X-Api-Key", c.APIKey)

--- a/client.go
+++ b/client.go
@@ -79,6 +79,8 @@ func (c *Client) request(method string, path string, reader io.Reader) ([]byte, 
 		return nil, wrapError(err, req, nil)
 	}
 
+	c.Log.Infof("HTTP %s %s - %s", method, url, res.Status)
+
 	defer res.Body.Close()
 	body, err := ioutil.ReadAll(res.Body)
 

--- a/client_test.go
+++ b/client_test.go
@@ -1,8 +1,6 @@
 package healthchecksio
 
 import (
-	"fmt"
-	"log"
 	"os"
 	"testing"
 )
@@ -14,13 +12,16 @@ func assertString(t *testing.T, expected string, actual string) {
 }
 
 func configureClient() *Client {
+	l := &StandardLogger{}
 	envKey := "HEALTHCHECKSIO_API_KEY"
 	apiKey := os.Getenv(envKey)
 	if apiKey == "" {
-		log.Println(fmt.Sprintf("API Key must be set (env: %s)", envKey))
+		l.Errorf("API Key must be set (env: %s)", envKey)
 		os.Exit(1)
 	}
-	return NewClient(apiKey)
+	c := NewClient(apiKey)
+	c.Log = l
+	return c
 }
 
 func TestClient(t *testing.T) {
@@ -39,7 +40,7 @@ func TestClient(t *testing.T) {
 		return
 	}
 
-	log.Printf("[DEBUG] Fetched %s", checks)
+	client.Log.Debugf("Fetched %s", checks)
 
 	// Create
 	// ----------------------------------------
@@ -55,7 +56,7 @@ func TestClient(t *testing.T) {
 		return
 	}
 
-	log.Printf("[DEBUG] Created %s", created)
+	client.Log.Debugf("[DEBUG] Created %s", created)
 
 	// Update
 	// ----------------------------------------
@@ -71,7 +72,7 @@ func TestClient(t *testing.T) {
 		return
 	}
 
-	log.Printf("[DEBUG] Updated %s", updated)
+	client.Log.Debugf("[DEBUG] Updated %s", updated)
 
 	// Pause
 	// ----------------------------------------
@@ -81,7 +82,7 @@ func TestClient(t *testing.T) {
 		return
 	}
 
-	log.Printf("[DEBUG] Paused %s", paused)
+	client.Log.Debugf("[DEBUG] Paused %s", paused)
 
 	// Delete
 	// ----------------------------------------
@@ -91,7 +92,7 @@ func TestClient(t *testing.T) {
 		return
 	}
 
-	log.Printf("[DEBUG] Deleted %s", deleted)
+	client.Log.Debugf("[DEBUG] Deleted %s", deleted)
 
 	// GetAllChannels
 	// ----------------------------------------
@@ -101,5 +102,5 @@ func TestClient(t *testing.T) {
 		return
 	}
 
-	log.Printf("[DEBUG] Fetched %s", channels)
+	client.Log.Debugf("[DEBUG] Fetched %s", channels)
 }

--- a/healtcheck.go
+++ b/healtcheck.go
@@ -5,6 +5,39 @@ import (
 	"strings"
 )
 
+// APIError represents an error that occured when talkinging to the Healthchecks.io api
+type APIError struct {
+	err        string
+	method     string
+	url        string
+	status     string
+	statusCode int
+}
+
+func (e *APIError) Error() string {
+	return e.err
+}
+
+// Method returns the HTTP request method
+func (e *APIError) Method() string {
+	return e.method
+}
+
+// URL returns the HTTP request URL
+func (e *APIError) URL() string {
+	return e.url
+}
+
+// Status returns the HTTP response status
+func (e *APIError) Status() string {
+	return e.status
+}
+
+// StatusCode returns the HTTP response status code
+func (e *APIError) StatusCode() int {
+	return e.statusCode
+}
+
 // Healthcheck represents a healthcheck
 type Healthcheck struct {
 	Channels string   `json:"channels,omitempty"`

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,46 @@
+package healthchecksio
+
+import (
+	"fmt"
+	"log"
+)
+
+// Logger defines the pluggable interface used for logging
+type Logger interface {
+	Debugf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+}
+
+// NoOpLogger is the default logger, logs nothing
+type NoOpLogger struct{}
+
+// Debugf logs nothing
+func (l *NoOpLogger) Debugf(format string, args ...interface{}) {}
+
+// Infof logs nothing
+func (l *NoOpLogger) Infof(format string, args ...interface{}) {}
+
+// Errorf logs nothing
+func (l *NoOpLogger) Errorf(format string, args ...interface{}) {}
+
+// StandardLogger is the default logger, logs nothing
+type StandardLogger struct{}
+
+// Debugf logs nothing
+func (l *StandardLogger) Debugf(format string, args ...interface{}) {
+	f := fmt.Sprintf("[DEBUG] %s", format)
+	log.Printf(f, args...)
+}
+
+// Infof logs nothing
+func (l *StandardLogger) Infof(format string, args ...interface{}) {
+	f := fmt.Sprintf("[INFO] %s", format)
+	log.Printf(f, args...)
+}
+
+// Errorf logs nothing
+func (l *StandardLogger) Errorf(format string, args ...interface{}) {
+	f := fmt.Sprintf("[ERROR] %s", format)
+	log.Printf(f, args...)
+}


### PR DESCRIPTION
To play nice with packages consuming this package we should wrap some errors to expose the Healthchecks.io API HTTP response status code etc.

I also added  a tiny interface, used for logging, that enables using any logger to display logs from this package.

I see no breaking changes, only added functionality. Would tag and release this as v1.2.0. See any issues with this approach? @masutaka 